### PR TITLE
Fix incompatibility with RenderLib 1.3.3+

### DIFF
--- a/src/main/java/dev/redstudio/valkyrie/mixin/MinecraftMixin.java
+++ b/src/main/java/dev/redstudio/valkyrie/mixin/MinecraftMixin.java
@@ -43,18 +43,18 @@ public class MinecraftMixin {
      * @reason Remove the version from the window title and add configurability.
      * @author Desoroxxx
      */
-    @Overwrite
-    private void createDisplay() throws LWJGLException {
-        Display.setResizable(true);
-        Display.setTitle(ValkyrieConfig.general.windowTitle + (FMLLaunchHandler.isDeobfuscatedEnvironment() ? " Development Environment" : ""));
+    @ModifyConstant(method = "createDisplay", constant = @Constant(stringValue = "Minecraft 1.12.2"))
+    private String modifyWindowTitle(String title) {
+        return ValkyrieConfig.general.windowTitle + (FMLLaunchHandler.isDeobfuscatedEnvironment() ? " Development Environment" : "");
+    }
 
-        try {
-            Display.create((new PixelFormat()).withDepthBits(ValkyrieConfig.general.highPrecisionDepthBuffer ? 32 : 24));
-        } catch (LWJGLException lwjglexception) {
-            RED_LOGGER.printFramedError("Minecraft Initialization", "Could not set pixel format", "Things relying on depth buffer precision may not work properly", lwjglexception.getMessage());
-
-            Display.create();
-        }
+    /**
+     * @reason Use 32 bit depth buffer if enabled in config.
+     * @author Desoroxxx
+     */
+    @ModifyConstant(method = "createDisplay", constant = @Constant(intValue = 24))
+    private int modifyDepthBits(int bits) {
+        return ValkyrieConfig.general.highPrecisionDepthBuffer ? 32 : 24;
     }
 
     /**


### PR DESCRIPTION
## 📝 Description

Replaces the mixin that overwrites the `Minecraft#createDisplay` method with two ModifyConstant mixins to fix compatibility with RenderLib 1.3.3+.

## 🎯 Goals

Fix compatibility with RenderLib 1.3.3+.

## ❌ Non Goals

Change any Valkyrie functionality or introduce new bugs.

## 🚦 Testing

Couldn't create a Valkyrie build and thus just created a test mod with the new ModifyConstant mixins.

## ⏮️ Backwards Compatibility

PR is backward compatible.

## 📚 Related Issues & Documents

#23 

## 🖼️ Screenshots/Recordings

*None*

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [ ] 🙅 No documentation needed

## 😄 [optional] What gif best describes this PR or how it makes you feel?

😶


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved flexibility and configurability of the window title and depth buffer settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->