### PR TITLE
Add dimension Blacklist/Whitelist for cloud rendering

### DIFF
--- a/src/main/java/dev/redstudio/valkyrie/config/ValkyrieConfig.java
+++ b/src/main/java/dev/redstudio/valkyrie/config/ValkyrieConfig.java
@@ -58,6 +58,10 @@ public class ValkyrieConfig {
 
             public boolean enabled = true;
 
+            public int[] dimensionList = {};
+
+            public boolean dimensionListIsBlacklist = true;
+
             public int height = 256;
             @Config.RangeInt(min = 4)
             public int renderDistance = 32;

--- a/src/main/java/dev/redstudio/valkyrie/renderer/CloudRenderer.java
+++ b/src/main/java/dev/redstudio/valkyrie/renderer/CloudRenderer.java
@@ -22,6 +22,7 @@ import org.lwjgl.opengl.GL11;
 
 import javax.annotation.Nonnull;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.function.Predicate;
 
 import static dev.redstudio.valkyrie.Valkyrie.MC;
@@ -203,7 +204,8 @@ public class CloudRenderer implements ISelectiveResourceReloadListener {
     }
 
     public void updateSettings() {
-        final boolean enabled = ValkyrieConfig.graphics.clouds.enabled && MC.world != null && MC.world.provider.isSurfaceWorld();
+        final boolean enabled = ValkyrieConfig.graphics.clouds.enabled && MC.world != null && MC.world.provider.isSurfaceWorld() &&
+                (Arrays.stream(ValkyrieConfig.graphics.clouds.dimensionList).anyMatch(n -> n == MC.world.provider.getDimension()) != ValkyrieConfig.graphics.clouds.dimensionListIsBlacklist);
 
         if (isBuilt() && (!enabled || ValkyrieConfig.graphics.clouds.renderDistance != renderDistance || ValkyrieConfig.graphics.clouds.layers != layers))
             dispose();

--- a/src/main/resources/assets/valkyrie/lang/en_us.lang
+++ b/src/main/resources/assets/valkyrie/lang/en_us.lang
@@ -60,6 +60,10 @@ valkyrie.general.graphics.clouds.tooltip=Configuration for the clouds
 
 valkyrie.general.graphics.clouds.enabled=Enabled
 valkyrie.general.graphics.clouds.enabled.tooltip=Whether or not clouds are enabled
+valkyrie.general.graphics.clouds.dimensionlist=Dimension List
+valkyrie.general.graphics.clouds.dimensionlist.tooltip=Dimension List where clouds are whitelisted/blacklisted
+valkyrie.general.graphics.clouds.dimensionlistisblacklist=Dimension List is Blacklist
+valkyrie.general.graphics.clouds.dimensionlistisblacklist.tooltip=If True, Dimension List will be treated as a Blacklist instead of a Whitelist
 valkyrie.general.graphics.clouds.height=Height
 valkyrie.general.graphics.clouds.height.tooltip=The height of the clouds
 valkyrie.general.graphics.clouds.renderdistance=Render Distance


### PR DESCRIPTION
## 📝 Description
This PR adds configuration that allows players and modpack makers to specify a list of dimensions where Cloud Rendering is enabled (whitelist) or not enabled (blacklist), by writing a list of dimension IDs and if such list is a blacklist or a whitelist, in mod configuration. Config is reloadable (no MC restart or World Reload required). Config are also localized, in line with the other config options

## 🎯 Goals
Enhance mod configurability and customizability

## ❌ Non Goals
The PR aims to *limit* where could can render, instead of adding cloud rendering to more dimensions. For example, this PR allows players to disable Clouds in The Overworld but not in Twilight Forest. Before this PR one could only enable or disable cloud rendering for both at the same time. This PR does not allow one to add clouds to The Nether or The End.

## 🚦 Testing
Tested in both dev environment and custom modpack (500+ mods)

## ⏮️ Backwards Compatibility
This chance is Backwards compatible. By default, the dimension list is an empty blacklist. Configuration still obeys to master switch "enable clouds", and players that update the mod without knowing this change, will not experience any change whatsoever

## 📚 Related Issues & Documents
None that I know of

## 🖼️ Screenshots/Recordings
Nothing to show, just new configs

## 📖 Added to documentation?
- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [X] 🙅 No documentation needed

## 😄 [optional] What gif best describes this PR or how it makes you feel?
Advanced Rocketry planets with clouds: 🤮

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options for cloud graphics, including the ability to whitelist or blacklist clouds in specific dimensions.
- **Enhancements**
	- Improved cloud rendering logic to respect the new dimension-based settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->