### PR TITLE
Create a config option for checking java version feature

### DIFF
--- a/src/main/java/dev/redstudio/valkyrie/Valkyrie.java
+++ b/src/main/java/dev/redstudio/valkyrie/Valkyrie.java
@@ -48,7 +48,8 @@ public final class Valkyrie {
     public static void preInit(FMLPreInitializationEvent preInitializationEvent) {
         snoozerFile = new File(preInitializationEvent.getModConfigurationDirectory() + "/" + VERSION + " Snoozer.txt");
 
-        new Thread(JvmCheckUtil::checkJavaVersion).start();
+        if (ValkyrieConfig.general.javaVersionCheck)
+            new Thread(JvmCheckUtil::checkJavaVersion).start();
     }
 
     @Mod.EventHandler

--- a/src/main/java/dev/redstudio/valkyrie/config/ValkyrieConfig.java
+++ b/src/main/java/dev/redstudio/valkyrie/config/ValkyrieConfig.java
@@ -29,6 +29,9 @@ public class ValkyrieConfig {
     public static class GeneralConfig {
 
         @Config.RequiresMcRestart
+        public boolean javaVersionCheck = true;
+
+        @Config.RequiresMcRestart
         public boolean highPrecisionDepthBuffer = false;
         public boolean customIcons = false;
 

--- a/src/main/resources/assets/valkyrie/lang/en_us.lang
+++ b/src/main/resources/assets/valkyrie/lang/en_us.lang
@@ -24,6 +24,8 @@ jvmCheck.ignore=Ignore
 valkyrie.general.general=General
 valkyrie.general.general.tooltip=General configuration
 
+valkyrie.general.general.javaversioncheck=Disable Outdated Java Version Check
+valkyrie.general.general.javaversioncheck.tooltip=Enable or disable the popup when using an outdated Java version.
 valkyrie.general.general.highprecisiondepthbuffer=High Precision Depth Buffer
 valkyrie.general.general.highprecisiondepthbuffer.tooltip=Whether or not to use high precision depth buffer, this doesn't seem to be important or change much, but might be useful in the future.
 valkyrie.general.general.windowtitle=Window Title


### PR DESCRIPTION
## 📝 Description

create a config option for the checking outdated Java version warning feature.

## 🎯 Goals

allow disabling the outdated Java warning for users who are aware of the situation and are unwilling or unable to update.

## ❌ Non Goals

changing the default behavior of warning the user that the Java version being used is outdated.

## 🚦 Testing

dev environment only, when the config is either enabled and disabled.

## ⏮️ Backwards Compatibility

the default option of the config option (`true`) maintains the same default behavior as prior to the introduction of this config option.

## 📚 Related Issues & Documents

resolves #63

## 🖼️ Screenshots/Recordings

N/A

## 📖 Added to documentation?

- [ ] 📜 README.md
- [ ] 📑 Documentation
- [ ] 📓 Javadoc
- [ ] 🍕 Comments
- [x] 🙅 No documentation needed
